### PR TITLE
HTTP POST support

### DIFF
--- a/cloudstack/compute/client.py
+++ b/cloudstack/compute/client.py
@@ -16,7 +16,7 @@ logging.basicConfig(format="%(asctime)s %(module)s[%(lineno)d] [%(levelname)s]: 
                     #filename = "log.txt",
                     level=logging.INFO)
 
-def connect(host=None,api_key=None,secret_key=None,debug=False):
+def connect(host=None,api_key=None,secret_key=None,http_method=None,debug=False):
     if debug:
         httplib2.debuglevel = 1
         logging.getLogger().setLevel(logging.DEBUG)
@@ -41,6 +41,14 @@ def connect(host=None,api_key=None,secret_key=None,debug=False):
             secret_key = os.environ.get('IDCF_COMPUTE_SECRET_KEY')
             if not secret_key:
                 secret_key = safe_option(config,"account","secret_key")
+        if not http_method:
+            http_method = os.environ.get("IDCF_COMPUTE_HTTP_METHOD")
+            if not http_method:
+                try:
+                    http_method = config.get("account", "http_method")
+                    http_method = http_method.upper()
+                except:
+                    http_method = "GET"
 
     except ConfigParser.NoSectionError, e:
         print >> sys.stderr, e.message
@@ -55,4 +63,4 @@ def connect(host=None,api_key=None,secret_key=None,debug=False):
     except Exception, e:
         print >> sys.stderr, e
         sys.exit(1)
-    return Stack(http,host,api_key,secret_key)
+    return Stack(http,host,api_key,secret_key,http_method)

--- a/cloudstack/compute/shell.py
+++ b/cloudstack/compute/shell.py
@@ -50,12 +50,16 @@ class ShellCommand(object):
 
         csv_fields = d.pop("csv")
         no_headers = d.pop("noheaders")
+        http_method = d.pop("method")
 
         for k,v in d.items():
             if v is None:
                 del(d[k])
 
-        retval = client.connect().get(command.__name__,d)
+        if http_method:
+            retval = client.connect().connect(http_method, command.__name__, d)
+        else:
+            retval = client.connect().request(command.__name__, d)
 
         return retval, fields, xml, csv_fields, no_headers
 
@@ -108,6 +112,11 @@ class IdcfShell(object):
                                   nargs="?", const="*"))
                 retval.append(arg("--noheaders",help="suppress csv header",
                                   action="store_true"))
+
+                retval.append(arg("-m", "--method", help="http method",
+                                  type=str.upper,
+                                  choices=["GET", "POST"]))
+
                 return retval
             setattr(command,"options",options)
             commands.append(command)

--- a/cloudstack/compute/stack.py
+++ b/cloudstack/compute/stack.py
@@ -14,11 +14,12 @@ import httplib2
 import hashlib
 
 class Stack(object):
-    def __init__(self, http, host, api_key, secret_key):
+    def __init__(self, http, host, api_key, secret_key, http_method):
         self.http = http
         self.host = host
         self.api_key = api_key
         self.secret_key = secret_key
+        self.http_method = http_method if http_method in ('GET', 'POST') else 'GET'
 
     def signature(self, command, query):
         query['command'] = command
@@ -66,3 +67,9 @@ class Stack(object):
 
     def get(self, command, query=None):
         return self.connect('GET',command,query)
+
+    def post(self, command, query=None):
+        return self.connect('POST', command,query)
+
+    def request(self, command, query=None):
+        return self.connect(self.http_method, command, query)


### PR DESCRIPTION
This patch enables to use HTTP POST to call API.
HTTP method can be specified by config file, environmental variable or command line option.